### PR TITLE
Fix copper backtank remaining air overlay not showing for origins with water breathing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 # Mod Info
 maven_group = dev.igalaxy
 archives_base_name = createorigins
-mod_version = 1.1.0
+mod_version = 1.2.0-fpl
 
 minecraft_version = 1.19.2
 
@@ -20,7 +20,7 @@ parchment_version = 2022.11.27
 
 # Create
 # https://modrinth.com/mod/create-fabric/versions
-create_version = 0.5.0.i-946+1.19.2
+create_version = 0.5.1-b-build.1079+mc1.19.2
 
 # Development QOL
 # Create supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.

--- a/src/main/java/dev/igalaxy/createorigins/CreateOrigins.java
+++ b/src/main/java/dev/igalaxy/createorigins/CreateOrigins.java
@@ -2,7 +2,7 @@ package dev.igalaxy.createorigins;
 
 import com.simibubi.create.Create;
 
-import com.simibubi.create.content.contraptions.goggles.GogglesItem;
+import com.simibubi.create.content.equipment.goggles.GogglesItem;
 
 import io.github.apace100.apoli.power.Power;
 import io.github.apace100.apoli.power.PowerType;
@@ -25,7 +25,7 @@ public class CreateOrigins implements ModInitializer {
 	public void onInitialize() {
 		LOGGER.info("Create addon mod [{}] is loading alongside Create [{}]!", NAME, Create.VERSION);
 
-		GogglesItem.addIsWearingPredicate(player -> GOGGLES.isActive(player));
+		GogglesItem.addIsWearingPredicate(GOGGLES::isActive);
 	}
 
 	public static ResourceLocation id(String path) {

--- a/src/main/java/dev/igalaxy/createorigins/mixin/CopperBacktankArmorLayerMixin.java
+++ b/src/main/java/dev/igalaxy/createorigins/mixin/CopperBacktankArmorLayerMixin.java
@@ -1,0 +1,23 @@
+package dev.igalaxy.createorigins.mixin;
+
+import com.simibubi.create.content.curiosities.armor.CopperBacktankArmorLayer;
+
+import io.github.apace100.origins.power.OriginsPowerTypes;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.level.material.Fluid;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(CopperBacktankArmorLayer.class)
+public class CopperBacktankArmorLayerMixin {
+	@Redirect(method = "renderRemainingAirOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 0))
+	private static boolean modifyRenderRemainingAirOverlay(LocalPlayer instance, TagKey<Fluid> tagKey) {
+		if (OriginsPowerTypes.WATER_BREATHING.isActive(instance)) {
+			return !instance.isEyeInFluid(tagKey);
+		}
+		return instance.isEyeInFluid(tagKey);
+	}
+}

--- a/src/main/java/dev/igalaxy/createorigins/mixin/DivingHelmetItemMixin.java
+++ b/src/main/java/dev/igalaxy/createorigins/mixin/DivingHelmetItemMixin.java
@@ -1,10 +1,12 @@
 package dev.igalaxy.createorigins.mixin;
 
-import com.simibubi.create.content.curiosities.armor.DivingHelmetItem;
+import com.simibubi.create.content.equipment.armor.DivingHelmetItem;
 
 import io.github.apace100.origins.power.OriginsPowerTypes;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.entity.LivingEntity;
+
+import net.minecraft.world.level.material.Fluid;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,8 +14,8 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(DivingHelmetItem.class)
 public class DivingHelmetItemMixin {
-	@Redirect(method = "breatheUnderwater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 1))
-	private static boolean modifyBreatheUnderwater(LivingEntity instance, TagKey tagKey) {
+	@Redirect(method = "breatheUnderwater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 0))
+	private static boolean modifyBreatheUnderwater(LivingEntity instance, TagKey<Fluid> tagKey) {
 		if (OriginsPowerTypes.WATER_BREATHING.isActive(instance)) {
 			return !instance.isEyeInFluid(tagKey);
 		}

--- a/src/main/java/dev/igalaxy/createorigins/mixin/RemainingAirOverlayMixin.java
+++ b/src/main/java/dev/igalaxy/createorigins/mixin/RemainingAirOverlayMixin.java
@@ -1,6 +1,6 @@
 package dev.igalaxy.createorigins.mixin;
 
-import com.simibubi.create.content.curiosities.armor.CopperBacktankArmorLayer;
+import com.simibubi.create.content.equipment.armor.RemainingAirOverlay;
 
 import io.github.apace100.origins.power.OriginsPowerTypes;
 import net.minecraft.client.player.LocalPlayer;
@@ -11,9 +11,9 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
-@Mixin(CopperBacktankArmorLayer.class)
-public class CopperBacktankArmorLayerMixin {
-	@Redirect(method = "renderRemainingAirOverlay", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 0))
+@Mixin(RemainingAirOverlay.class)
+public class RemainingAirOverlayMixin {
+	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 0))
 	private static boolean modifyRenderRemainingAirOverlay(LocalPlayer instance, TagKey<Fluid> tagKey) {
 		if (OriginsPowerTypes.WATER_BREATHING.isActive(instance)) {
 			return !instance.isEyeInFluid(tagKey);

--- a/src/main/resources/createorigins.mixins.json
+++ b/src/main/resources/createorigins.mixins.json
@@ -4,7 +4,7 @@
   "package": "dev.igalaxy.createorigins.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "CopperBacktankArmorLayerMixin",
+    "RemainingAirOverlayMixin",
     "DivingHelmetItemMixin"
   ],
   "client": [

--- a/src/main/resources/createorigins.mixins.json
+++ b/src/main/resources/createorigins.mixins.json
@@ -4,6 +4,7 @@
   "package": "dev.igalaxy.createorigins.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
+    "CopperBacktankArmorLayerMixin",
     "DivingHelmetItemMixin"
   ],
   "client": [


### PR DESCRIPTION
Something to consider: Since both mixin functions are nearly identical, maybe an utility function should be created like `boolean isEyeInFluid(LivingEntity instance, TagKey<Fluid> tagKey)`?