### PR TITLE
Create 0.5.1 compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs=-Xmx2G
 # Mod Info
 maven_group = dev.igalaxy
 archives_base_name = createorigins
-mod_version = 1.1.0
+mod_version = 1.1.1
 
 minecraft_version = 1.19.2
 
@@ -20,7 +20,7 @@ parchment_version = 2022.11.27
 
 # Create
 # https://modrinth.com/mod/create-fabric/versions
-create_version = 0.5.0.i-946+1.19.2
+create_version = 0.5.1-b-build.1079+mc1.19.2
 
 # Development QOL
 # Create supports all 3 recipe viewers: JEI, REI, and EMI. This decides which is enabled at runtime.

--- a/src/main/java/dev/igalaxy/createorigins/CreateOrigins.java
+++ b/src/main/java/dev/igalaxy/createorigins/CreateOrigins.java
@@ -2,7 +2,7 @@ package dev.igalaxy.createorigins;
 
 import com.simibubi.create.Create;
 
-import com.simibubi.create.content.contraptions.goggles.GogglesItem;
+import com.simibubi.create.content.equipment.goggles.GogglesItem;
 
 import io.github.apace100.apoli.power.Power;
 import io.github.apace100.apoli.power.PowerType;

--- a/src/main/java/dev/igalaxy/createorigins/mixin/DivingHelmetItemMixin.java
+++ b/src/main/java/dev/igalaxy/createorigins/mixin/DivingHelmetItemMixin.java
@@ -1,6 +1,6 @@
 package dev.igalaxy.createorigins.mixin;
 
-import com.simibubi.create.content.curiosities.armor.DivingHelmetItem;
+import com.simibubi.create.content.equipment.armor.DivingHelmetItem;
 
 import io.github.apace100.origins.power.OriginsPowerTypes;
 import net.minecraft.tags.TagKey;
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(DivingHelmetItem.class)
 public class DivingHelmetItemMixin {
-	@Redirect(method = "breatheUnderwater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z", ordinal = 1))
+	@Redirect(method = "breatheUnderwater", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z"))
 	private static boolean modifyBreatheUnderwater(LivingEntity instance, TagKey tagKey) {
 		if (OriginsPowerTypes.WATER_BREATHING.isActive(instance)) {
 			return !instance.isEyeInFluid(tagKey);

--- a/src/main/java/dev/igalaxy/createorigins/mixin/RemainingAirOverlayMixin.java
+++ b/src/main/java/dev/igalaxy/createorigins/mixin/RemainingAirOverlayMixin.java
@@ -1,0 +1,25 @@
+package dev.igalaxy.createorigins.mixin;
+
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.simibubi.create.content.equipment.armor.RemainingAirOverlay;
+
+import io.github.apace100.origins.power.OriginsPowerTypes;
+import net.minecraft.client.player.LocalPlayer;
+
+import net.minecraft.tags.TagKey;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(RemainingAirOverlay.class)
+public class RemainingAirOverlayMixin {
+	@Redirect(method = "render", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;isEyeInFluid(Lnet/minecraft/tags/TagKey;)Z"))
+	private static boolean modifyRender(LocalPlayer player, TagKey key) {
+		if(OriginsPowerTypes.WATER_BREATHING.isActive(player)) {
+			return !player.isEyeInFluid(key);
+		} else {
+			return player.isEyeInFluid(key);
+		}
+	}
+}

--- a/src/main/resources/createorigins.mixins.json
+++ b/src/main/resources/createorigins.mixins.json
@@ -4,7 +4,8 @@
   "package": "dev.igalaxy.createorigins.mixin",
   "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "DivingHelmetItemMixin"
+    "DivingHelmetItemMixin",
+    "RemainingAirOverlayMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
Added:
- Mixin for RemainingAirOverlay to show remaining oxygen in tank when out of water as any class with `origins:water_breathing` power. 
 
Changes:
- Fixed gradle.properties to use current version of Create (0.5.1-b-build.1079+mc1.19.2)
- Fixed class paths to match Create 0.5.1 updated paths
- Fixed mixins

Please, do review the changes made thoroughly, I am NOT used to Fabric.
The changes were tested both in Singleplayer and Multiplayer on both Fabric and Quilt. No bugs were found during testing.